### PR TITLE
Support v3 of API and dynamics templates

### DIFF
--- a/lib/nodemailer-sendinblue-transport.js
+++ b/lib/nodemailer-sendinblue-transport.js
@@ -32,14 +32,18 @@ function V3Compliant() {
         if (VERSION === 3) {
             delete body.from, body.text, body.html;
             Object.assign(body, { 
-                sender: V3Compliant.address(data.from),
+              sender: V3Compliant.address(data.from)
+            });
+            if (!data.params && !data.templateId) {
+              Object.assign(body, { 
                 textContent: data.text,
                 htmlContent: data.html
             });
+            }
             if (data.params) { 
                 Object.assign(body, {
                     params: data.params
-                })
+                });
             }
             if (data.templateId) { 
                 Object.assign(body, {

--- a/lib/nodemailer-sendinblue-transport.js
+++ b/lib/nodemailer-sendinblue-transport.js
@@ -11,7 +11,142 @@ var pkg           = require("../package.json");
 //
 // Constants
 //
-var STATUS_OK = 200;
+var STATUS_OK   = 200;
+
+//
+// V3 simple compliance
+//
+function V3Compliant() {
+
+    var STATUS   = 201;
+    var VERSION  = 2;
+
+    var init = function(options) {
+        var regex = new RegExp(/\/v[0-9]{1}/i);
+        if (regex.test(options.apiUrl)) {
+            VERSION = parseInt( regex.exec( options.apiUrl ).shift().substr(-1), 10 );   
+        }
+    };
+
+    var body = function(body, data) {
+        if (VERSION === 3) {
+            delete body.from, body.text, body.html;
+            Object.assign(body, { 
+                sender: V3Compliant.address(data.from),
+                textContent: data.text,
+                htmlContent: data.html
+            });
+            if (data.params) { 
+                Object.assign(body, {
+                    params: data.params
+                })
+            }
+            if (data.templateId) { 
+                Object.assign(body, {
+                    templateId: data.templateId
+                })
+            }
+            body.to = V3Compliant.addresses(data.to);
+            body.cc = V3Compliant.addresses(data.cc);
+            body.bcc = V3Compliant.addresses(data.bcc);
+            body.replyto = V3Compliant.addresses(data.replyTo); 
+        }
+        return body;
+    };
+
+    var address = function(address) {
+        if (typeof address === 'string') {
+            return { email: address };
+        }
+        return address
+    };
+
+    var addresses = function(addresses) {
+        if (Array.isArray(addresses)) {
+            return addresses.map( (address) => {
+              return V3Compliant.address(address);
+            });
+        }
+        return V3Compliant.address(addresses);
+    };
+
+    var attachment = function(attachment) {
+        return new Promise( (resolve, reject) => {
+            if (!attachment.filename) {
+                reject('one of name or filename is required');
+            }
+            if (!attachment.url && !attachment.path && !attachment.href && !attachment.content) {
+                reject('one of url, path, href or content must be defined');
+            }
+            if (attachment.url || attachment.href) {
+                resolve({ url : attachment.url || attachment.href, name: attachment.filename });
+            } else if (attachment.path) {
+                var data = fs.readFileSync(attachment.path);
+                resolve({ content : data.toString("base64"), name: attachment.filename });
+            } else if (attachment.content) {
+                resolve({ content : /[A-Za-z0-9+/=]/.test(attachment.content) ? attachment.content : attachment.content.toString("base64"), name: attachment.filename });
+            } else {
+                resolve(null)
+            }
+        });
+    };
+
+    var attachments = function(attachments, callback) {
+        return new Promise( (resolve, reject) => {
+            if (VERSION === 2) {
+                resolve( callback(attachments) );
+            }
+            if (!Array.isArray(attachments)) {
+                reject('attachments property must be an array');
+            }
+            var generated = [];
+            attachments.forEach( (attachment, index) => {
+                V3Compliant.attachment(attachment)
+                .then( (a) => {
+                    generated.push(a);
+                    if (index === attachments.length -1) { resolve(generated); }
+                })
+                .catch( (e) => {
+                    reject(e.message);
+                });
+            })
+        });
+    };
+
+    var statusCode = function(statusCode) {
+        return VERSION === 3 ? statusCode === STATUS : statusCode === STATUS_OK;
+    };
+
+    var makeInfo = function(body,res) {
+        if (VERSION === 3) {
+            return {
+                messageId: body["messageId"] || "",
+                res: res
+            };
+        }
+        return {
+            messageId: body.data["message-id"] || "",
+            code: body.code,
+            message: body.message,
+            res: res
+        };
+    };
+
+    var self = {};
+    
+    self.init = init;
+    self.body = body;
+    self.address = address;
+    self.addresses = addresses;
+    self.statusCode = statusCode;
+    self.makeInfo = makeInfo;
+    self.attachment = attachment;
+    self.attachments = attachments;
+
+    return self;
+}
+
+var V3Compliant = V3Compliant();
 
 //
 // Helper
@@ -191,11 +326,7 @@ function buildAttachments(attachments) {
 }
 
 function isErrorResponse(response) {
-    if (response.statusCode !== STATUS_OK) {
-        return true;
-    }
-
-    return false;
+    return !V3Compliant.statusCode(response.statusCode);
 }
 
 function responseError(response, body) {
@@ -206,18 +337,16 @@ function responseError(response, body) {
             response.statusCode));
 }
 
-function makeInfo(body) {
-    return {
-        messageId: body.data["message-id"] || "",
-        code: body.code,
-        message: body.message
-    };
+function makeInfo(body,res) {
+    return V3Compliant.makeInfo(body,res);
 }
 
-//
-// Transport class
-//
+/**
+ * @description Transport class
+ * @constructor
+ */
 function SendinBlueTransport(options) {
+
     this.name    = "SendinBlue";
     this.version = pkg.version;
 
@@ -225,17 +354,21 @@ function SendinBlueTransport(options) {
         options.apiUrl = "https://api.sendinblue.com/v2.0";
     }
 
+    V3Compliant.init(options);
+
     this.reqOptions = url.parse(options.apiUrl + "/email");
     this.reqOptions.method = "POST";
     this.reqOptions.headers = {
         "api-key": options.apiKey || "",
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        "Accept": "application/json"
     };
 
     this.reqBuilder = this.reqOptions.protocol === "https:" ? https.request : http.request;
 }
 
 SendinBlueTransport.prototype.send = function (mail, callback) {
+
     var req = this.reqBuilder(this.reqOptions, function (res) {
         res.setEncoding("utf-8");
 
@@ -254,7 +387,7 @@ SendinBlueTransport.prototype.send = function (mail, callback) {
                 return callback(responseError(res, body));
             }
 
-            callback(undefined, makeInfo(body));
+            callback(undefined, makeInfo(body, res));
         });
     });
 
@@ -271,7 +404,9 @@ SendinBlueTransport.prototype.send = function (mail, callback) {
 };
 
 SendinBlueTransport.prototype.buildBody = function (mail) {
+
     var data = mail.data;
+  
     var body = {
         from:    transformFromAddresses(data.from),
         to:      transformAddresses(data.to),
@@ -285,13 +420,16 @@ SendinBlueTransport.prototype.buildBody = function (mail) {
     };
 
     if (!data.attachments) {
-        return Promise.resolve(body);
+        return Promise.resolve(V3Compliant.body(body, data));
     }
 
-    return buildAttachments(data.attachments).then(function (attachments) {
+    return V3Compliant.attachments(data.attachments, buildAttachments)
+    .then(function (attachments) {
         body.attachment = attachments;
-        return body;
-    });
+        return V3Compliant.body(body, data);
+    })
+    .catch( (e) => { return body; });
+
 };
 
 module.exports = function (options) {


### PR DESCRIPTION
Hi Marcel,

First of all, thank you for the work done. 

For a personal project, I needed to improve some features, in particular the support of the Sendinblue v3 API, and the ability to send emails based on dynamics templates.

This is a very little patch, really, because I'm override the payload when the endpoint is the V3. Simply. This is working and does not lead breaking changes. I did not write any unit tests.

What do you think about it?