### PR TITLE
fix attachment array

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -98,6 +98,7 @@ async function buildAttachment(attachment) {
 }
 
 async function buildAttachements(attachments) {
+    if(!attachments ||!attachments.length) return undefined
     return await Promise.all(attachments.map((a) => buildAttachment(a)));
 }
 


### PR DESCRIPTION
when attachments are not present the property attachmets shoud not be present at all. 
Sendingblue retunr a 400 error code `Invalid attachment passed in request. (code: invalid_parameter, statusCode: 400)`

fixes #10 