### PR TITLE
Return a messageId from Brevo API

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -181,15 +181,9 @@ class Transport {
                         chunks.push(data);
                     }).on("end", () => {
                         let body = {};
-                        let useMessageId = messageId
                         try {
                             let data = chunks.join("");
                             body = JSON.parse(data);
-                            console.log("body", body)
-                            if (body.messageId) {
-                                console.log("messageId", body.messageId)
-                                useMessageId = body.messageId;
-                            }
                         } catch (err) {
                             /* Ignore error */
                         }
@@ -201,7 +195,7 @@ class Transport {
                         }
 
                         resolve({
-                            messageId: useMessageId,
+                            messageId: body.messageId || messageId,
                             envelope,
                         });
                     });

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -181,12 +181,14 @@ class Transport {
                         chunks.push(data);
                     }).on("end", () => {
                         let body = {};
+                        let useMessageId = messageId
                         try {
                             let data = chunks.join("");
                             body = JSON.parse(data);
                             console.log("body", body)
                             if (body.messageId) {
-                                messageId = body.messageId;
+                                console.log("messageId", body.messageId)
+                                useMessageId = body.messageId;
                             }
                         } catch (err) {
                             /* Ignore error */
@@ -199,7 +201,7 @@ class Transport {
                         }
 
                         resolve({
-                            messageId,
+                            messageId: useMessageId,
                             envelope,
                         });
                     });

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -184,6 +184,10 @@ class Transport {
                         try {
                             let data = chunks.join("");
                             body = JSON.parse(data);
+                            console.log("body", body)
+                            if (body.messageId) {
+                                messageId = body.messageId;
+                            }
                         } catch (err) {
                             /* Ignore error */
                         }


### PR DESCRIPTION
The message ID returned from the transporter was different from the one in Brevo. I was able to pass the message ID returned from the Brevo API. After this change, it is now possible to associate these IDs with the one passed to the webhook endpoint, for example.